### PR TITLE
Accept alphanumeric version components

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -75,6 +75,9 @@ kotlin {
             implementation("net.sf.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01")
             implementation("org.slf4j:slf4j-simple:2.0.17")
         }
+        jvmTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/com/combat/nomm/Version.kt
+++ b/composeApp/src/jvmMain/kotlin/com/combat/nomm/Version.kt
@@ -10,8 +10,8 @@ import kotlinx.serialization.encoding.Encoder
 
 
 @Serializable(with = VersionSerializer::class)
-class Version(vararg components: Int) : Comparable<Version> {
-    private val parts: List<Int> = components.toList()
+class Version private constructor(private val parts: List<String>) : Comparable<Version> {
+    constructor(vararg components: Int) : this(components.map { it.toString() })
 
     override fun toString(): String = parts.joinToString(".")
 
@@ -26,15 +26,35 @@ class Version(vararg components: Int) : Comparable<Version> {
     override fun compareTo(other: Version): Int {
         val maxLength = maxOf(this.parts.size, other.parts.size)
         for (i in 0 until maxLength) {
-            val thisPart = this.parts.getOrElse(i) { 0 }
-            val otherPart = other.parts.getOrElse(i) { 0 }
-            if (thisPart != otherPart) {
-                return thisPart.compareTo(otherPart)
+            val thisPart = this.parts.getOrElse(i) { "0" }
+            val otherPart = other.parts.getOrElse(i) { "0" }
+            val comparison = comparePart(thisPart, otherPart)
+            if (comparison != 0) {
+                return comparison
             }
         }
         return 0
     }
 
+    private fun comparePart(left: String, right: String): Int {
+        val leftNumber = left.filter(Char::isDigit).toIntOrNull()
+        val rightNumber = right.filter(Char::isDigit).toIntOrNull()
+
+        return when {
+            leftNumber != null && rightNumber != null -> leftNumber.compareTo(rightNumber)
+            leftNumber != null -> 1
+            rightNumber != null -> -1
+            else -> left.compareTo(right, ignoreCase = true)
+        }
+    }
+
+    companion object {
+        fun parse(value: String): Version {
+            val parts = value.split('.')
+            require(parts.all { it.isNotEmpty() }) { "Invalid version: $value" }
+            return Version(parts)
+        }
+    }
 }
 
 object VersionSerializer : KSerializer<Version> {
@@ -46,11 +66,6 @@ object VersionSerializer : KSerializer<Version> {
     }
 
     override fun deserialize(decoder: Decoder): Version {
-        val string = decoder.decodeString()
-        val parts = string.split('.')
-            .map { it.replace("\\D+".toRegex() ,"").toInt() }
-            .toIntArray()
-
-        return Version(*parts)
+        return Version.parse(decoder.decodeString())
     }
 }

--- a/composeApp/src/jvmTest/kotlin/com/combat/nomm/VersionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/combat/nomm/VersionTest.kt
@@ -1,0 +1,28 @@
+package com.combat.nomm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VersionTest {
+    @Test
+    fun deserializesAlphabeticVersionComponent() {
+        val version = json.decodeFromString<Version>("\"1.0.a\"")
+
+        assertEquals("1.0.a", version.toString())
+        assertEquals("\"1.0.a\"", json.encodeToString(version))
+    }
+
+    @Test
+    fun alphabeticVersionSortsBeforeNumericRelease() {
+        assertTrue(Version.parse("1.0.a") < Version(1, 0, 0))
+        assertTrue(Version(1, 0, 1) > Version.parse("1.0.a"))
+    }
+
+    @Test
+    fun numericVersionsKeepExistingComparisonBehavior() {
+        assertEquals(0, Version(1).compareTo(Version(1, 0)))
+        assertTrue(Version(1, 1) > Version(1, 0, 9))
+        assertEquals(0, Version.parse("v5.4.23.4").compareTo(Version(5, 4, 23, 4)))
+    }
+}


### PR DESCRIPTION
## Summary

- preserve alphanumeric version components during manifest deserialization
- compare alphabetic components consistently while retaining existing numeric and `v5...` behavior
- add regression tests for `1.0.a` serialization and ordering

## Root cause

The live NOMNOM manifest contains the artifact version `1.0.a`. The existing serializer removed non-digit characters from every component and then parsed the result as an integer. The final `a` component became an empty string, causing a `NumberFormatException` that rejected the entire manifest and left Discover empty.

## Verification

- `./gradlew.bat :composeApp:jvmTest`
- launched NOMM against the live manifest
- confirmed all 127 entries were cached, including `qol.combofix` version `1.0.a`

Fixes #17
