### PR TITLE
Fix Windows Launch Game button stalling before Steam

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/combat/nomm/MainNavigationRail.kt
+++ b/composeApp/src/jvmMain/kotlin/com/combat/nomm/MainNavigationRail.kt
@@ -123,9 +123,12 @@ fun MainNavigationRail(
                 val state = LocalWindowState.current
                 FloatingActionButton(
                     onClick = {
+                        // Steam discovery can be waiting on its worker while holding its mutex.
+                        // Launch Windows first so worker shutdown cannot block the button.
+                        if (!launchWindowsSteamUri()) {
+                            launchNuclearOption()
+                        }
                         state.isMinimized = true
-                        launchNuclearOption()
-
                     },
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
@@ -144,6 +147,22 @@ fun MainNavigationRail(
 }
 
 private val launching = AtomicBoolean(false)
+
+private fun launchWindowsSteamUri(): Boolean {
+    if (!System.getProperty("os.name").lowercase().contains("win")) return false
+
+    return try {
+        val steamUri = "steam://rungameid/2168680"
+        ProcessBuilder(
+            "cmd.exe", "/d", "/s", "/c",
+            "start \"\" \"$steamUri\""
+        ).start()
+        true
+    } catch (e: Exception) {
+        println("[NOMM] Direct Windows launch failed: " + e.message)
+        false
+    }
+}
 
 fun launchNuclearOption() {
     if (!launching.compareAndSet(false, true)) {


### PR DESCRIPTION
## Issue

On Windows, clicking **Launch Game** can minimize NOMM without starting Nuclear Option.

The button currently calls `launchNuclearOption()`, which waits for the Steam-discovery worker to shut down before it sends the Steam launch request. If that worker path is still waiting during initialization or shutdown, the launch request is never reached.

## Fix

For the main Windows launch button:

- Send `steam://rungameid/2168680` immediately using a correctly quoted `cmd /d /s /c start` command.
- Minimize NOMM only after the Steam request has been started.
- Keep the existing launch routine as the fallback, and keep existing behavior on non-Windows systems.

This removes the worker shutdown dependency from the Windows button without changing mod installation or selection.

## Verification

- Reproduced with NOMM 5.0.4 on Windows x64: the original button minimized NOMM but did not create the game process.
- Verified the direct Steam URI launches `NuclearOption.exe` through Steam and the configured BepInEx mods load.
- `./gradlew.bat :composeApp:compileKotlinJvm` passes.