### PR TITLE
Fix Launch Game no-op and false already-running state on Windows

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -80,6 +80,10 @@ kotlin {
             implementation("net.sf.sevenzipjbinding:sevenzipjbinding-all-platforms:16.02-2.01")
             implementation("org.slf4j:slf4j-simple:2.0.17")
         }
+
+        jvmTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/com/combat/nomm/MainNavigationRail.kt
+++ b/composeApp/src/jvmMain/kotlin/com/combat/nomm/MainNavigationRail.kt
@@ -18,6 +18,7 @@ import androidx.navigation3.runtime.NavKey
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import nuclearoptionmodmanager.composeapp.generated.resources.*
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
@@ -123,8 +124,8 @@ fun MainNavigationRail(
                 val state = LocalWindowState.current
                 FloatingActionButton(
                     onClick = {
-                        state.isMinimized = true
                         launchNuclearOption()
+                        state.isMinimized = true
 
                     },
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -144,6 +145,77 @@ fun MainNavigationRail(
 }
 
 private val launching = AtomicBoolean(false)
+private const val STEAM_WORKER_RELEASE_DELAY_MILLIS = 1_500L
+private const val STEAM_LAUNCH_RETRY_DELAY_MILLIS = 5_000L
+
+internal fun windowsSteamLaunchCommand(steamUri: String): List<String> = listOf(
+    "cmd.exe", "/d", "/s", "/c",
+    "start \"\" \"$steamUri\""
+)
+
+private fun launchNuclearOptionOnWindows() {
+    try {
+        if (SteamDiscovery.isGameRunning()) {
+            println("[NOMM] Game is already running, skipping launch")
+            launching.set(false)
+            return
+        }
+
+        println("[NOMM] Stopping Steam worker before Windows launch")
+        SteamDiscovery.stopWorkerForGameLaunch()
+        // Steam can retain the worker's app-ID session briefly after the process exits.
+        // A request sent during that window is silently discarded as already running.
+        Thread.sleep(STEAM_WORKER_RELEASE_DELAY_MILLIS)
+
+        val steamUri = "steam://rungameid/2168680"
+        println("[NOMM] Launching game via Steam: $steamUri")
+        ProcessBuilder(windowsSteamLaunchCommand(steamUri)).start()
+    } catch (e: Exception) {
+        println("[NOMM] Steam launch failed, falling back to exe: " + e.message)
+        val exeFile = File(SettingsManager.gameFolder, "NuclearOption.exe")
+        if (!exeFile.exists()) {
+            println("[NOMM] Game exe not found, cannot launch")
+            launching.set(false)
+            return
+        }
+        ProcessBuilder(exeFile.absolutePath)
+            .directory(exeFile.parentFile)
+            .start()
+    }
+
+    scope.launch(Dispatchers.IO) {
+        try {
+            println("[NOMM] Waiting for game to start...")
+            val gameStarted = withTimeoutOrNull(60_000L) {
+                val retryAt = System.currentTimeMillis() + STEAM_LAUNCH_RETRY_DELAY_MILLIS
+                var retried = false
+                while (!SteamDiscovery.isGameRunning()) {
+                    if (!retried && System.currentTimeMillis() >= retryAt) {
+                        println("[NOMM] Game not detected; retrying Steam launch once")
+                        ProcessBuilder(windowsSteamLaunchCommand("steam://rungameid/2168680")).start()
+                        retried = true
+                    }
+                    delay(1000L)
+                }
+                true
+            } ?: false
+            if (!gameStarted) {
+                println("[NOMM] Game did not start within 60 seconds")
+                return@launch
+            }
+
+            println("[NOMM] Waiting for game to exit...")
+            while (SteamDiscovery.isGameRunning()) {
+                delay(5000L)
+            }
+            println("[NOMM] Game exited")
+        } finally {
+            println("[NOMM] Restarting Steam worker")
+            SteamDiscovery.init()
+            launching.set(false)
+        }
+    }
+}
 
 fun launchNuclearOption() {
     if (!launching.compareAndSet(false, true)) {
@@ -151,7 +223,13 @@ fun launchNuclearOption() {
         return
     }
 
+    if (System.getProperty("os.name").lowercase().contains("win")) {
+        launchNuclearOptionOnWindows()
+        return
+    }
+
     scope.launch(Dispatchers.IO) {
+        var steamWorkerStopped = false
         try {
             if (SteamDiscovery.isGameRunning()) {
                 println("[NOMM] Game is already running, skipping launch")
@@ -160,6 +238,7 @@ fun launchNuclearOption() {
 
             println("[NOMM] Shutting down Steam worker before launch")
             SteamDiscovery.shutdown()
+            steamWorkerStopped = true
             delay(1000L)
 
             val launched = try {
@@ -168,7 +247,7 @@ fun launchNuclearOption() {
                 println("[NOMM] Launching game via Steam: $steamUri")
                 when {
                     os.contains("win") -> {
-                        ProcessBuilder("cmd.exe", "/c", "start", "", steamUri).start()
+                        ProcessBuilder(windowsSteamLaunchCommand(steamUri)).start()
                     }
                     os.contains("mac") -> {
                         ProcessBuilder("open", steamUri).start()
@@ -209,18 +288,29 @@ fun launchNuclearOption() {
                     .start()
             }
 
-            println("[NOMM] Waiting for game to exit...")
-            while (!SteamDiscovery.isGameRunning()) {
-                delay(1000L)
+            println("[NOMM] Waiting for game to start...")
+            val gameStarted = withTimeoutOrNull(60_000L) {
+                while (!SteamDiscovery.isGameRunning()) {
+                    delay(1000L)
+                }
+                true
+            } ?: false
+            if (!gameStarted) {
+                println("[NOMM] Game did not start within 60 seconds")
+                return@launch
             }
+
+            println("[NOMM] Waiting for game to exit...")
             while (SteamDiscovery.isGameRunning()) {
                 delay(5000L)
             }
             println("[NOMM] Game exited")
 
-            println("[NOMM] Restarting Steam worker")
-            SteamDiscovery.init()
         } finally {
+            if (steamWorkerStopped) {
+                println("[NOMM] Restarting Steam worker")
+                SteamDiscovery.init()
+            }
             launching.set(false)
         }
     }

--- a/composeApp/src/jvmMain/kotlin/com/combat/nomm/SteamDiscovery.kt
+++ b/composeApp/src/jvmMain/kotlin/com/combat/nomm/SteamDiscovery.kt
@@ -31,9 +31,10 @@ object SteamDiscovery {
     private val pendingPings = ConcurrentHashMap<String, (ServerInfo?) -> Unit>()
     private val pendingRulesCallbacks = ConcurrentHashMap<String, (Map<String, String>?) -> Unit>()
     private val pendingLobbyMetadataCallbacks = ConcurrentHashMap<String, (Map<String, String>?) -> Unit>()
+    private const val INIT_TIMEOUT_MILLIS = 15_000L
 
     suspend fun init(): InitStatus {
-        lock.withLock {
+        val deferred = lock.withLock {
             if (initResult.value == InitStatus.OK) return InitStatus.OK
             if (running) return InitStatus.NotInitialized
 
@@ -42,32 +43,50 @@ object SteamDiscovery {
                 fixSteamSdkPath()
             }
 
-            initDeferred = CompletableDeferred()
+            val newDeferred = CompletableDeferred<InitStatus>()
+            initDeferred = newDeferred
 
-            val process = spawnWorker()
-            workerProcess = process
-            val workerIpc = SteamWorkerIPC(process.inputStream, process.outputStream)
-            ipc = workerIpc
+            try {
+                val process = spawnWorker()
+                workerProcess = process
+                val workerIpc = SteamWorkerIPC(process.inputStream, process.outputStream)
+                ipc = workerIpc
 
-            running = true
-            eventReaderJob = scope.launch {
-                readEvents(workerIpc)
-            }
+                running = true
+                eventReaderJob = scope.launch {
+                    readEvents(workerIpc)
+                }
 
-            workerIpc.sendCommand(WorkerCommand.Init)
-
-            val status = initDeferred!!.await()
-            initDeferred = null
-            initResult.value = status
-
-            if (status != InitStatus.OK) {
-                running = false
+                workerIpc.sendCommand(WorkerCommand.Init)
+            } catch (e: Exception) {
+                println("[NOMM] Steam worker failed to start: " + e.message)
                 shutdownWorker()
+                initResult.value = InitStatus.FailedGeneric
+                return InitStatus.FailedGeneric
             }
 
-            println("[NOMM] Steam init: $status")
-            return status
+            newDeferred
         }
+
+        val status = withTimeoutOrNull(INIT_TIMEOUT_MILLIS) {
+            deferred.await()
+        } ?: InitStatus.FailedGeneric.also {
+            println("[NOMM] Steam worker initialization timed out")
+        }
+
+        lock.withLock {
+            // shutdown() may have already completed and cleared this attempt.
+            if (initDeferred === deferred) {
+                initDeferred = null
+                if (status != InitStatus.OK) {
+                    shutdownWorker()
+                }
+                initResult.value = status
+            }
+        }
+
+        println("[NOMM] Steam init: $status")
+        return status
     }
 
     private suspend fun readEvents(workerIpc: SteamWorkerIPC) {
@@ -184,15 +203,50 @@ object SteamDiscovery {
         }
     }
 
-    private suspend fun shutdownWorker() {
+    internal fun stopWorkerForGameLaunch() {
         running = false
+        initDeferred?.complete(InitStatus.FailedGeneric)
+        initDeferred = null
 
         try {
             ipc?.sendCommand(WorkerCommand.Shutdown)
         } catch (_: Exception) {
         }
 
-        ipc?.close()
+        val process = workerProcess
+        workerProcess = null
+        try {
+            process?.destroyForcibly()
+            process?.waitFor(2, TimeUnit.SECONDS)
+        } catch (_: Exception) {
+        }
+
+        try {
+            ipc?.close()
+        } catch (_: Exception) {
+        }
+        ipc = null
+
+        eventReaderJob?.cancel()
+        eventReaderJob = null
+        initResult.value = InitStatus.NotInitialized
+        isRefreshing.value = false
+    }
+
+    private suspend fun shutdownWorker() {
+        running = false
+        initDeferred?.complete(InitStatus.FailedGeneric)
+        initDeferred = null
+
+        try {
+            ipc?.sendCommand(WorkerCommand.Shutdown)
+        } catch (_: Exception) {
+        }
+
+        try {
+            ipc?.close()
+        } catch (_: Exception) {
+        }
         ipc = null
 
         eventReaderJob?.cancelAndJoin()
@@ -211,36 +265,28 @@ object SteamDiscovery {
         isRefreshing.value = false
     }
 
-    private var lastGameRunningCheck = 0L
-    private var lastGameRunningResult = false
+    internal fun isNuclearOptionExecutable(command: String?): Boolean =
+        command?.let { File(it).name.equals("NuclearOption.exe", ignoreCase = true) } == true
 
-    fun isGameRunning(): Boolean {
-        val now = System.currentTimeMillis()
-        if (now - lastGameRunningCheck < 5000) return lastGameRunningResult
-        lastGameRunningCheck = now
-
-        lastGameRunningResult = try {
-            val os = System.getProperty("os.name").lowercase()
-            val output = if (os.contains("win")) {
-                val process = ProcessBuilder(
-                    "powershell", "-NoProfile", "-Command",
-                    "Get-Process -Name 'NuclearOption' -ErrorAction SilentlyContinue | Select-Object -First 1"
-                ).redirectErrorStream(true).start()
-                val result = process.inputStream.bufferedReader().use { it.readText() }
-                process.waitFor()
-                result
-            } else {
-                val process = ProcessBuilder("pgrep", "-f", "NuclearOption")
-                    .redirectErrorStream(true).start()
-                val result = process.inputStream.bufferedReader().use { it.readText() }
-                process.waitFor()
-                result
+    fun isGameRunning(): Boolean = try {
+        val os = System.getProperty("os.name").lowercase()
+        if (os.contains("win")) {
+            val processes = ProcessHandle.allProcesses()
+            try {
+                processes.anyMatch { process ->
+                    isNuclearOptionExecutable(process.info().command().orElse(null))
+                }
+            } finally {
+                processes.close()
             }
-            output.trim().isNotEmpty()
-        } catch (_: Exception) {
-            false
+        } else {
+            val process = ProcessBuilder("pgrep", "-f", "NuclearOption")
+                .redirectErrorStream(true).start()
+            process.inputStream.bufferedReader().use { it.readText() }
+            process.waitFor() == 0
         }
-        return lastGameRunningResult
+    } catch (_: Exception) {
+        false
     }
 
     fun requestServerList() {

--- a/composeApp/src/jvmTest/kotlin/com/combat/nomm/WindowsSteamLaunchCommandTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/combat/nomm/WindowsSteamLaunchCommandTest.kt
@@ -1,0 +1,37 @@
+package com.combat.nomm
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WindowsSteamLaunchCommandTest {
+    @Test
+    fun quotesSteamUriAsOneCmdCommand() {
+        val steamUri = "steam://rungameid/2168680"
+
+        assertEquals(
+            listOf(
+                "cmd.exe",
+                "/d",
+                "/s",
+                "/c",
+                "start \"\" \"$steamUri\"",
+            ),
+            windowsSteamLaunchCommand(steamUri),
+        )
+    }
+
+    @Test
+    fun detectsOnlyNuclearOptionExecutable() {
+        assertTrue(
+            SteamDiscovery.isNuclearOptionExecutable(
+                "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Nuclear Option\\NuclearOption.exe"
+            )
+        )
+        assertTrue(SteamDiscovery.isNuclearOptionExecutable("C:\\Games\\NUCLEAROPTION.EXE"))
+        assertFalse(SteamDiscovery.isNuclearOptionExecutable(null))
+        assertFalse(SteamDiscovery.isNuclearOptionExecutable("C:\\Program Files\\NOMM\\NOMM.exe"))
+        assertFalse(SteamDiscovery.isNuclearOptionExecutable("powershell.exe"))
+    }
+}


### PR DESCRIPTION
## Symptoms

On Windows, clicking **Launch Game** can appear to do nothing:

- NOMM minimizes, but Steam does not start Nuclear Option.
- No useful error is shown.
- Later clicks may also do nothing.
- Steam may report that Nuclear Option is already running even when no game process exists.
- Closing and reopening NOMM, or waiting after the game exits, can temporarily change the behavior.

The game path, Steam protocol handler, and installed mods can all be valid.

## Root causes

NOMM starts a Steamworks helper under Nuclear Option's Steam app ID (2168680) for server discovery. Three lifecycle problems made launching unreliable:

1. `isGameRunning()` cached its result for five seconds. If Nuclear Option exited during that window, Launch Game reused stale `true`, logged `Game is already running, skipping launch`, and returned without contacting Steam. This was the directly observed cause of the repeatable no-op.
2. Steam could retain the helper's app-ID session briefly after the helper process exited. A launch request sent in that window could be rejected as already running or silently dropped.
3. Steam-discovery initialization awaited the helper's `InitComplete` event while holding the mutex needed by shutdown. If that event never arrived, Launch Game could wait forever before reaching Steam, leaving the launch guard set so later clicks were ignored.

The button also minimized NOMM before scheduling the launch, hiding these failures without confirming a Steam handoff.

## Fix

- Replace the cached PowerShell-based Windows game check with a live `ProcessHandle` scan that matches only `NuclearOption.exe`.
- Stop and forcibly reap the Steamworks helper before invoking `steam://rungameid/2168680`.
- Allow Steam 1.5 seconds to release the helper's app-ID session and retry the URI once after five seconds if no game process appears.
- Issue the Steam handoff before minimizing NOMM.
- Quote the `cmd.exe /d /s /c start` command correctly.
- Release the discovery mutex before awaiting worker initialization, bound initialization to 15 seconds, and clear pending initialization during shutdown.
- Bound game-start detection to 60 seconds and restart discovery from `finally` after exit or timeout.
- Preserve the direct executable fallback when the Steam protocol launch itself fails.

## Verification

- Captured the failed click in NOMM's own output: `Game is already running, skipping launch`, while Windows showed no `NuclearOption.exe` process.
- Added JVM regression coverage for the exact Steam command and executable-name matching, including null and non-game processes.
- `./gradlew.bat :composeApp:jvmTest :composeApp:packageReleasePortable :composeApp:createReleaseDistributable` passes.
- End-to-end Windows test after installing the fix logged helper shutdown, Steam URI handoff, startup detection, and wait-for-exit; `NuclearOption.exe` launched and was responsive.
- Verified the Desktop portable executable matches the built artifact and all 355 installed release files match the build byte-for-byte.